### PR TITLE
Add Memory To Docker Build

### DIFF
--- a/main.js
+++ b/main.js
@@ -145,7 +145,7 @@ console.log(`Building ${info_branch} ->  ${stage}-${stack_name}-service...this m
  }
 
 
-run(`docker build -f Dockerfile${extension} -t "${repoString}" . --build-arg environment=${branch}`);
+run(`docker build --memory=8g -f Dockerfile${extension} -t "${repoString}" . --build-arg environment=${branch}`);
 
 console.log("AWS GET Account, Login And Upload To ECR");
 


### PR DESCRIPTION
I don't know if this is helpful, but it's the recommendation Doug gave a couple days ago. I don't know if we've tried it, but we keep running in to that error on build...

$ docker build -f Dockerfile.nonprod -t "staging-inthearena-react-repo" . --build-arg environment=staging
child_process.js:660
    throw err;
    ^

Error: spawnSync /bin/bash ENOBUFS
    at Object.spawnSync (internal/child_process.js:1041:20)
    at spawnSync (child_process.js:607:24)
    at execSync (child_process.js:652:15)
    at run (/home/runner/work/_actions/gitgregoryjones/secretsdeploy/v23/main.js:47:12)